### PR TITLE
Add N5193A lan streaming example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 PyArbTools: Keysight Signal Generator Control & Waveform Creation
 =================================================================
 
-*Current version: 2021.01.15*
+*Current version: 2021.01.1*
 
 Frustrated after looking through hundreds of pages of user manuals to find out how to download a waveform to a signal generator?
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 PyArbTools: Keysight Signal Generator Control & Waveform Creation
 =================================================================
 
-*Current version: 2020.09.2*
+*Current version: 2021.01.15*
 
 Frustrated after looking through hundreds of pages of user manuals to find out how to download a waveform to a signal generator?
 

--- a/pyarbtools/instruments.py
+++ b/pyarbtools/instruments.py
@@ -2095,6 +2095,25 @@ class AnalogUXG(socketscpi.SocketInstrument):
 
         return pdwFile
 
+
+    def bin_raw_pdw_block_builder(self, pdwList):
+        """
+        Builds binary raw pdw block without header or end block for lan streaming
+        Args:
+            pdwList (list): List of lists. Each inner list contains a single pulse descriptor word.
+
+        Returns:
+            (bytes): Binary data that contains a binary block of raw 28 byte
+             PDWs without headers or other information to stream directly over
+             N5193A LAN port 5033
+        """
+        # Build Raw PDW Data from list
+        rawPdws = [pdwBuilder.analog_bin_pdw_builder(*p) for p in pdwList]
+        rawPdws = b''.join(rawPdws)
+
+        return rawPdws
+
+
     def download_bin_pdw_file(self, pdwFile, pdwName='wfm'):
         """
         Downloads binary PDW file to PDW directory in UXG.
@@ -2336,13 +2355,13 @@ class VectorUXG(socketscpi.SocketInstrument):
             (bytes): Binary data that contains a full PDW file that can
                 be downloaded to and played out of the UXG.
         """
-        
+
         pdwFile = pdwBuilder.vector_bin_pdw_file_builder(pdwList)
-        
+
         self.err_check()
-        
+
         return pdwFile
-        
+
     # noinspection PyDefaultArgument,PyDefaultArgument
     def csv_pdw_file_download(self, fileName, fields=['Operation', 'Time'], data=[[1, 0], [2, 100e-6]]):
         """

--- a/pyarbtools/pdwBuilder.py
+++ b/pyarbtools/pdwBuilder.py
@@ -369,11 +369,16 @@ def analog_bin_pdw_file_builder(pdwList):
     pdwSize = (0xffffffffffffffff).to_bytes(8, byteorder='little')
     pdwBlock = [pdwBlockId, res4, pdwSize]
 
-    # Build PDW file from header, padBlock, pdwBlock, and PDWs
-    pdwFile = header + fpcBlock + paddingBlock + pdwBlock
+    # Build Raw PDW Data from list
+    rawPdwData = [analog_bin_pdw_builder(*p) for p in pdwList]
+    # Add 8 bytes of zero to make sure PDW block ends on 16 byte boundary.
+    rawPdwData += [(0).to_bytes(8, byteorder='little')]
 
-    pdwFile += [analog_bin_pdw_builder(*p) for p in pdwList]
-    pdwFile += [(0).to_bytes(24, byteorder='little')]
+    pdwEndBlock = [(0).to_bytes(16, byteorder='little')]
+
+    # Build PDW file from header, padBlock, pdwBlock, and PDWs
+    pdwFile = header + fpcBlock + paddingBlock + pdwBlock + rawPdwData + pdwEndBlock
+
     # Convert arrays of data to a single byte-type variable
     pdwFile = b''.join(pdwFile)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-wheel
-flake8
-Sphinx
-twine
 numpy
 scipy
 socketscpi


### PR DESCRIPTION
requirements.txt:
 removed non-run time requirements to simplify install
  
pdwBuilder.py:
 analog_bin_pdw_file_builder() - separated raw pdw section and end block for mode intuitive block separation
  
instruments.py:
 AnalogUXG():
  added bin_raw_pdw_block_builder() to build raw pdws without headers for direct lan streaming
  
examples.py:
 added analog_uxg_lan_stream_pdw_example() for direct lan streaming
 
 renamed analog_uxg_file_stream_pdw_example - added file to name to distinguish from lan streaming
  