### PR TITLE
Vector uxg pdw updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 PyArbTools: Keysight Signal Generator Control & Waveform Creation
 =================================================================
 
-*Current version: 2021.02.4*
+*Current version: 2021.05.1*
 
 Frustrated after looking through hundreds of pages of user manuals to find out how to download a waveform to a signal generator?
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -111,3 +111,12 @@ History
 ----------------------
 
 * Fixed bug with ``ampScale`` argument in ``cw_pulse_generator()``.
+
+
+2021.05.1 (2021-05-14)
+----------------------
+
+* Added N5194A Vector UXG support for PDW format 3 rev B that was introduced in firmware A.01.30.  Updated vector uxg example names to better reflect what the examples do.
+* Refined N5193A file streaming to define size of PDW block
+* Reformatted comments related to analog and vector PDW sections to be more easy to read.
+

--- a/examples.py
+++ b/examples.py
@@ -328,9 +328,10 @@ def vector_uxg_dig_mod_example(ipAddress):
     uxg.disconnect()
 
 
-def vector_uxg_pdw_file_streaming_example(ipAddress):
-    """Creates and downloads a chirp waveform, defines a simple pdw csv
-    file, and loads that pdw file into the UXG, and plays it out."""
+def vector_uxg_csv_to_pdw_file_streaming_example(ipAddress):
+    """Creates and downloads a chirp waveform, defines a simple csv pdw
+    file, and sends that pdw file into the UXG, the UXG converts the CSV
+    file to a binary pdw file and plays it."""
 
     uxg = pyarbtools.instruments.VectorUXG(ipAddress, port=5025, timeout=10, reset=True)
 
@@ -341,9 +342,10 @@ def vector_uxg_pdw_file_streaming_example(ipAddress):
 
     uxg.configure(amp=amplitude, rfState=output, cf=freq)
 
-    """Configure pdw markers. These commands will assign a TTL pulse
-    at the beginning of each PDW. The trigger 2 output will only be
-    active if the Marker field for a given PDW is specified as '0x1'"""
+    """Configure pdw markers.  These commands will assign PDW marker 1
+    to the vector UXG trigger out 2 port, so a TTL trigger will be sent
+    when marker 1 is active on a PDW.  Marker field '0x1'
+    """
     uxg.write("stream:markers:pdw1:mode stime")
     uxg.write("route:trigger2:output pmarker1")
 
@@ -359,21 +361,20 @@ def vector_uxg_pdw_file_streaming_example(ipAddress):
     # Define and generate csv pdw file
     pdwName = "basic_chirp"
 
-    # 'fields' list define the PDW fields positionally
+    # 'fields' list define the CSV PDW fields positionally
     fields = ["Operation", "Time", "Frequency", "Zero/Hold", "Markers", "Name"]
 
     # 'data' is a list of lists, where each inner list defines
     # the PDW using positional values for the fields defined above
-    data = [
-        [1, 0, 975e6, "Hold", "0x1", wfmName],
-        [0, 30e-6, 1025e6, "Hold", "0x0", wfmName],
-        [2, 60e-6, 1e9, "Hold", "0x0", wfmName],
-    ]
+    data = [[1, 0    , 975e6 , "Hold", "0x1", wfmName],
+            [0, 30e-6, 1025e6, "Hold", "0x0", wfmName],
+            [2, 60e-6, 1e9   , "Hold", "0x0", wfmName]]
 
     # Note: the last PDW starting with a '2' in the 'Operation'
     # field marks the end of the PDW stream and does not play
 
-    # Download PDW file using an intermediate csv file
+    # Upload CSV PDW file using an intermediate csv file.  The
+    # uxg will convert the CSV file to a binary pdw file
     uxg.csv_pdw_file_download(pdwName, fields, data)
 
     # Begin PDW streaming
@@ -384,50 +385,19 @@ def vector_uxg_pdw_file_streaming_example(ipAddress):
     uxg.disconnect()
 
 
-def vector_uxg_lan_streaming_example(ipAddress):
+def vector_uxg_lan_bin_file_streaming_example(ipAddress):
     """Creates and downloads iq waveforms & a waveform index file,
     builds a PDW file, configures LAN streaming, and streams the PDWs
     to the UXG.
 
-    This streams five pulses. To capture this, PDW 1 will output a hardware
-    trigger on the N5194A trigger output 2.
+    This streams pulses. To capture this, PDW marker 1 will output
+    a hardware trigger on the N5194A trigger output 2.
     """
 
-    # Create vector UXG object
-    uxg = pyarbtools.instruments.VectorUXG(ipAddress, port=5025, timeout=10, reset=True)
+    # Call shared lan setup routine
+    uxg = vector_uxg_lan_streaming_setup(ipAddress)
 
-    # UXG configuration variables
-    amplitude = -5
-    output = 0
-    modulation = 1
-
-    # Configure UXG and clear all waveform memory
-    uxg.configure(amp=amplitude, rfState=output, modState=modulation)
-    uxg.clear_all_wfm()
-
-    # Waveform definition variables, three chirps of the same bandwidth and different lengths
-    #bandwidth = 100e6
-    bandwidth = 1e6
-    #lengths = [100e-6, 500e-6, 1000e-6]
-    lengths = [100e-6, 200e-6, 300e-6]
-    wfmNames = []
-    fileName = "chirps"
-
-    # Create and download waveforms to UXG and save a list of names used for each wfm
-    for l in lengths:
-        iq = pyarbtools.wfmBuilder.chirp_generator(fs=uxg.fs, pWidth=l, pri=l, chirpBw=bandwidth,
-                                                   wfmFormat="iq", zeroLast=True)
-        uxg.download_wfm(iq, f"{l}_100MHz_CHIRP")
-        wfmNames.append(f"{l}_100MHz_CHIRP")
-
-    # Create waveform index file using the file name and wfm names we saved
-    windex = {"fileName": fileName, "wfmNames": wfmNames}
-
-    # Download waveform index file so the UXG knows what
-    # waveforms correspond to the wIndex field in the PDWs
-    uxg.csv_windex_file_download(windex)
-
-    # Create PDWs
+    # Create PDWs - format 3 rev B
     # operation, freq, phase, startTimeSec, widthInSec, maxPower,
     # markers, powerDbm, phaseControl, rfOff, autoBlank, newWaveform,
     # zeroHold, loLead, wfmMkrMask, wIndex, power2dBm, maxPower2dBm,
@@ -448,29 +418,13 @@ def vector_uxg_lan_streaming_example(ipAddress):
 
     pdwFile = uxg.bin_pdw_file_builder(rawPdw)
 
-    # Write pdw stream to file for troubleshootingsu
-    uxg.download_bin_pdw_file(pdwFile, pdwName="tempStream")
+    # Write pdw stream to unused file for troubleshooting
+    uxg.upload_bin_pdw_file(pdwFile, pdwName="tempStream")
     uxg.err_check()
 
-    # Separate pdwFile into header and data portions (AUTOMATE THIS)
+    # Separate pdwFile into header and data portions
     header = pdwFile[:4096]
     data = pdwFile[4096:]
-
-    # Configure LAN streaming using SCPI commands (AUTOMATE THIS)
-    uxg.write("stream:source lan")
-    uxg.write("stream:trigger:play:file:type continuous")
-    uxg.write("stream:trigger:play:file:type:continuous:type trigger")
-    uxg.write("stream:trigger:play:source bus")
-
-    # Route PDW Marker 1 to N5194A trigger 2 output using SCPI commands
-    uxg.write("route:connectors:trigger2:output pmarker1")
-
-    # Load waveform index file and select it as the reference file for streaming
-    uxg.write(f'memory:import:windex "{windex["fileName"]}.csv","{windex["fileName"]}"')
-    uxg.write(f'stream:windex:select "{windex["fileName"]}"')
-
-    # Clear the stream header to prepare for a new stream
-    uxg.write("stream:external:header:clear")
 
     """ADVANCED"""
     # The esr=False argument in binblockwrite() allows you to send your own
@@ -485,7 +439,6 @@ def vector_uxg_lan_streaming_example(ipAddress):
                                         " This should never happen.")
 
     # Configure LAN streaming and send PDWs
-    # uxg.write('stream:state on')
     uxg.open_lan_stream()
 
     # If RF is turned on before this point a CW tone will appear before pulses
@@ -497,12 +450,111 @@ def vector_uxg_lan_streaming_example(ipAddress):
     # Ensure everything is synchronized
     uxg.query("*opc?")
 
-    # Begin streaming
+    # Begin streaming clock
     uxg.write("stream:trigger:play:immediate")
 
     # Check for errors and gracefully disconnect.
     uxg.err_check()
     uxg.disconnect()
+
+
+def vector_uxg_lan_streaming_setup(ipAddress):
+    # Shared lan streaming setup method
+    # Create vector UXG object
+    uxg = pyarbtools.instruments.VectorUXG(ipAddress, port=5025, timeout=10, reset=True)
+    # UXG configuration variables
+    amplitude = -5
+    output = 0
+    modulation = 1
+    # Configure UXG and clear all waveform memory
+    uxg.configure(amp=amplitude, rfState=output, modState=modulation)
+    uxg.clear_all_wfm()
+    # Waveform definition variables, three chirps of the same bandwidth and different lengths
+    bandwidthMhz = 10
+    lengths = [100e-6, 200e-6, 300e-6]
+    wfmNames = []
+    fileName = "chirps"
+    # Create and download waveforms to UXG and save a list of names used for each wfm
+    for l in lengths:
+        iq = pyarbtools.wfmBuilder.chirp_generator(
+            fs=uxg.fs, pWidth=l, pri=l, chirpBw=bandwidthMhz * 1e6,
+            wfmFormat="iq", zeroLast=True)
+
+        uxg.download_wfm(iq, f"{l}_{bandwidthMhz}MHz_CHIRP")
+        wfmNames.append(f"{l}_{bandwidthMhz}MHz_CHIRP")
+    # Create waveform index file using the file name and wfm names we saved
+    windex = {"fileName": fileName, "wfmNames": wfmNames}
+    # Download waveform index file so the UXG knows what
+    # waveforms correspond to the wIndex field in the PDWs
+    uxg.csv_windex_file_download(windex)
+    # Configure LAN streaming using SCPI commands
+    uxg.write("stream:source lan")
+    uxg.write("stream:trigger:play:file:type continuous")
+    uxg.write("stream:trigger:play:file:type:continuous:type trigger")
+    uxg.write("stream:trigger:play:source bus")
+    # Route PDW Marker 1 to N5194A trigger 2 output using SCPI commands
+    uxg.write("route:connectors:trigger2:output pmarker1")
+    # Load waveform index file and select it as the reference file for streaming
+    uxg.write(f'memory:import:windex "{windex["fileName"]}.csv",'
+              f'"{windex["fileName"]}"')
+    uxg.write(f'stream:windex:select "{windex["fileName"]}"')
+    # Clear the stream header to prepare for a new stream
+    uxg.write("stream:external:header:clear")
+    return uxg
+
+
+def vector_uxg_lan_stream_pdw_example(ipAddress):
+    """Creates and downloads iq waveforms & a waveform index file,
+    builds a binary PDW block, configures LAN streaming, and streams
+    the raw PDWs to the UXG using raw LAN streaming WITHOUT A HEADER.
+
+    This streams pulses. To capture this, PDW marker 1 will output a
+    hardware trigger on the N5194A trigger output 2.
+    """
+
+    # Call shared lan setup routine
+    uxg = vector_uxg_lan_streaming_setup(ipAddress)
+
+    # Create PDWs - format 3 rev B
+    # operation, freq, phase, startTimeSec, widthInSec, maxPower,
+    # markers, powerDbm, phaseControl, rfOff, autoBlank, newWaveform,
+    # zeroHold, loLead, wfmMkrMask, wIndex, power2dBm, maxPower2dBm,
+    # dopplerHz
+    # See documentation for bin_pdw_file_builder for more info
+
+    rawPdw = [
+        [1,  .950e9, 0, 1000e-6,  0, -5, 1, -10, 0, 0, 1, 1, 0, 0, 0xF, 0],
+        [0,  .975e9, 0, 3000e-6,  0, -5, 0, -10, 0, 0, 1, 1, 0, 0, 0xF, 1],
+        [0,     1e9, 0, 5000e-6,  0, -5, 0, -10, 0, 0, 1, 1, 0, 0, 0xF, 1],
+        [0, 1.025e9, 0, 7000e-6,  0, -5, 0, -10, 0, 0, 1, 1, 0, 0, 0xF, 2],
+        [0, 1.050e9, 0, 9000e-6,  0, -5, 0, -10, 0, 0, 1, 1, 0, 0, 0xF, 2],
+        [2,     1e9, 0,11000e-6,  0, -5, 0, -10, 0, 0, 1, 1, 0, 0, 0xF, 0]
+    ]
+
+    # Note: the last PDW starting with a '2' in the 'Operation'
+    # field marks the end of the PDW stream and does not play
+
+    pdwData = uxg.build_raw_pdw_block(rawPdw)
+
+    # Configure LAN streaming and send PDWs
+    uxg.open_lan_stream()
+
+    # If RF is turned on before this point a CW tone will appear before pulses
+    uxg.configure(rfState=1, modState=1)
+
+    # Use the separate LAN socket specifically opened for PDW streaming
+    uxg.lanStream.send(pdwData)
+
+    # Ensure everything is synchronized
+    uxg.query("*opc?")
+
+    # Begin streaming clock
+    uxg.write("stream:trigger:play:immediate")
+
+    # Check for errors and gracefully disconnect.
+    uxg.err_check()
+    uxg.disconnect()
+
 
 
 def analog_uxg_file_stream_pdw_example(ipAddress):
@@ -616,93 +668,6 @@ def analog_uxg_lan_stream_pdw_example(ipAddress):
     # Check for errors and gracefully disconnect
     uxg.err_check()
     uxg.disconnect()
-
-
-def vector_uxg_lan_stream_pdw_example(ipAddress):
-    """Creates and downloads iq waveforms & a waveform index file,
-    builds a PDW file, configures LAN streaming, and streams the PDWs
-    to the UXG using raw LAN streaming
-
-    This streams five pulses. To capture this, PDW 1 will output a hardware
-    trigger on the N5194A trigger output 2.
-    """
-
-    # Create vector UXG object
-    uxg = pyarbtools.instruments.VectorUXG(ipAddress, port=5025, timeout=10, reset=True)
-
-    # UXG configuration variables
-    amplitude = -5
-    output = 0
-    modulation = 1
-
-    # Configure UXG and clear all waveform memory
-    uxg.configure(amp=amplitude, rfState=output, modState=modulation)
-    uxg.clear_all_wfm()
-
-    # Waveform definition variables, three chirps of the same bandwidth and different lengths
-    bandwidth = 100e6
-    lengths = [10e-6, 50e-6, 100e-6]
-    wfmNames = []
-    fileName = "chirps"
-
-    # Create and download waveforms to UXG and save a list of names used for each wfm
-    for l in lengths:
-        iq = pyarbtools.wfmBuilder.chirp_generator(fs=uxg.fs, pWidth=l, pri=l,
-                                                   chirpBw=bandwidth, wfmFormat="iq",
-                                                   zeroLast=True)
-        uxg.download_wfm(iq, f"{l}_100MHz_CHIRP")
-        wfmNames.append(f"{l}_100MHz_CHIRP")
-
-    # Create waveform index file using the file name and wfm names we saved
-    windex = {"fileName": fileName, "wfmNames": wfmNames}
-
-    # Download waveform index file so the UXG knows what
-    # waveforms correspond to the wIndex field in the PDWs
-    uxg.csv_windex_file_download(windex)
-    #
-    # uxg.open_lan_stream()
-    # uxg.query("*OPC?")
-    #
-    # uxg.write("*TRG")
-    # uxg.query("*OPC?")
-    # # Press local key after this point to view PDW playback stats
-    #
-    # burstStartTimeSec = 1
-    # burstRepetitionSec = 0.5
-    # numberOfBursts = 20
-    #
-    # firstBurst = True
-    #
-    # for dwellNumber in range(numberOfBursts):
-    #     # operation, freq, phase, startTimeSec, width, power, markers,
-    #     # pulseMode, phaseControl, bandAdjust, chirpControl, fpc_code_selection,
-    #     # chirpRate, freqMap
-    #
-    #     if firstBurst:
-    #         mop = 1
-    #     else:
-    #         mop = 0
-    #
-    #     pdwList = [
-    #         [mop, 980e6, 0, burstStartTimeSec + 0, 10e-6, 1, 1, 2, 0, 0, 3, 0, 4000000, 0,],
-    #         [0, 1e9, 0, burstStartTimeSec + 20e-6, 15e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
-    #         [0, 1.01e9, 0, burstStartTimeSec + 40e-6, 20e-6, 1, 0, 2, 0, 0, 0, 2, 0, 0],
-    #         [0, 1e9, 0, burstStartTimeSec + 80e-6, 5e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
-    #     ]
-    #     binPdwBurst = uxg.bin_raw_pdw_block_builder(pdwList)
-    #
-    #     # Stream pdw block
-    #     uxg.lanStream.send(binPdwBurst)
-    #     burstStartTimeSec += burstRepetitionSec
-    #
-    #     firstBurst = False
-    #
-    #     # Note: the last PDW mode of operations can be set to
-    #     # '2' to reset the stream clock
-    #
-    # # Check for errors and gracefully disconnect
-    # uxg.err_check()
-    # uxg.disconnect()
 
 
 def wfm_to_vsa_example(ipAddress):
@@ -846,9 +811,10 @@ def main():
     # vsg_dig_mod_example(ipAddress)
     # vsg_am_example(ipAddress)
     # vsg_mtone_example(ipAddress)
-    # vector_uxg_dig_mod_example(ipAddress)
-    # vector_uxg_pdw_file_streaming_example(ipAddress)
-    vector_uxg_lan_streaming_example(ipAddress)
+    vector_uxg_dig_mod_example(ipAddress)
+    # vector_uxg_csv_to_pdw_file_streaming_example(ipAddress)
+    # vector_uxg_lan_bin_file_streaming_example(ipAddress)
+    # vector_uxg_lan_stream_pdw_example(ipAddress)
     # analog_uxg_file_stream_pdw_example(ipAddress)
     # analog_uxg_lan_stream_pdw_example(ipAddress)
     # wfm_to_vsa_example(ipAddress)

--- a/examples.py
+++ b/examples.py
@@ -556,7 +556,6 @@ def vector_uxg_lan_stream_pdw_example(ipAddress):
     uxg.disconnect()
 
 
-
 def analog_uxg_file_stream_pdw_example(ipAddress):
     """Defines a pdw file for a chirp, and loads the
     pdw file into the UXG, and plays it out."""
@@ -580,10 +579,10 @@ def analog_uxg_file_stream_pdw_example(ipAddress):
     # pulseMode, phaseControl, bandAdjust, chirpControl, fpc_code_selection,
     # chirpRate, freqMap
     pdwList = [
-        [1, 980e6, 0, 0, 10e-6, 1, 0, 2, 0, 0, 3, 0, 4000000, 0],
-        [0, 1e9, 0, 20e-6, 15e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
-        [0, 1.01e9, 0, 40e-6, 20e-6, 1, 0, 2, 0, 0, 0, 2, 0, 0],
-        [2, 1e9, 0, 80e-6, 5e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
+        [1, 980e6 , 0, 0    , 10e-6, 1, 0, 2, 0, 0, 3, 0, 4000000, 0],
+        [0, 1e9   , 0, 20e-6, 15e-6, 1, 0, 2, 0, 0, 0, 1, 0      , 0],
+        [0, 1.01e9, 0, 40e-6, 20e-6, 1, 0, 2, 0, 0, 0, 2, 0      , 0],
+        [2, 1e9   , 0, 80e-6, 5e-6 , 1, 0, 2, 0, 0, 0, 1, 0      , 0]
     ]
     pdwFile = uxg.bin_pdw_file_builder(pdwList)
 
@@ -622,6 +621,7 @@ def analog_uxg_lan_stream_pdw_example(ipAddress):
 
     # Set stream-play marker to trigger 2 output
     uxg.write("stream:markers:pdw1:mode begin")
+    # Trigger 2 will not be available when Multi Box Sync is active.
     uxg.write("rout:trigger2:output pmarker1")
     uxg.err_check()
 
@@ -649,10 +649,10 @@ def analog_uxg_lan_stream_pdw_example(ipAddress):
             mop = 0
 
         pdwList = [
-            [mop, 980e6, 0, burstStartTimeSec + 0, 10e-6, 1, 1, 2, 0, 0, 3, 0, 4000000, 0,],
-            [0, 1e9, 0, burstStartTimeSec + 20e-6, 15e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
-            [0, 1.01e9, 0, burstStartTimeSec + 40e-6, 20e-6, 1, 0, 2, 0, 0, 0, 2, 0, 0],
-            [0, 1e9, 0, burstStartTimeSec + 80e-6, 5e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
+            [mop, 980e6 , 0, burstStartTimeSec + 0    , 10e-6, 1, 1, 2, 0, 0, 3, 0, 4000000, 0,],
+            [0  , 1e9   , 0, burstStartTimeSec + 20e-6, 15e-6, 1, 0, 2, 0, 0, 0, 1, 0, 0],
+            [0  , 1.01e9, 0, burstStartTimeSec + 40e-6, 20e-6, 1, 0, 2, 0, 0, 0, 2, 0, 0],
+            [0  , 1e9   , 0, burstStartTimeSec + 80e-6, 5e-6 , 1, 0, 2, 0, 0, 0, 1, 0, 0]
         ]
         binPdwBurst = uxg.bin_raw_pdw_block_builder(pdwList)
 
@@ -799,7 +799,7 @@ def main():
     """Uncomment the example you'd like to run. For each example,
     replace the IP address with one that is appropriate for your
     instrument(s)."""
-    ipAddress = "10.0.0.164"
+    ipAddress = "10.0.0.47"
     matFilePath = "<insert path to .mat file here>"
 
     # m8190a_simple_wfm_example(ipAddress)
@@ -811,11 +811,11 @@ def main():
     # vsg_dig_mod_example(ipAddress)
     # vsg_am_example(ipAddress)
     # vsg_mtone_example(ipAddress)
-    vector_uxg_dig_mod_example(ipAddress)
+    # vector_uxg_dig_mod_example(ipAddress)
     # vector_uxg_csv_to_pdw_file_streaming_example(ipAddress)
     # vector_uxg_lan_bin_file_streaming_example(ipAddress)
     # vector_uxg_lan_stream_pdw_example(ipAddress)
-    # analog_uxg_file_stream_pdw_example(ipAddress)
+    analog_uxg_file_stream_pdw_example(ipAddress)
     # analog_uxg_lan_stream_pdw_example(ipAddress)
     # wfm_to_vsa_example(ipAddress)
     # vsa_vector_example(ipAddress)

--- a/examples.py
+++ b/examples.py
@@ -815,13 +815,13 @@ def main():
     # vector_uxg_csv_to_pdw_file_streaming_example(ipAddress)
     # vector_uxg_lan_bin_file_streaming_example(ipAddress)
     # vector_uxg_lan_stream_pdw_example(ipAddress)
-    analog_uxg_file_stream_pdw_example(ipAddress)
+    # analog_uxg_file_stream_pdw_example(ipAddress)
     # analog_uxg_lan_stream_pdw_example(ipAddress)
     # wfm_to_vsa_example(ipAddress)
     # vsa_vector_example(ipAddress)
     # vxg_mat_import_example(ipAddress, fileName=matFilePath)
     # m8190a_sequence_example(ipAddress)
-    # gui_example()
+    gui_example()
 
 
 if __name__ == "__main__":

--- a/pyarbtools/instruments.py
+++ b/pyarbtools/instruments.py
@@ -691,7 +691,7 @@ class M8190A(socketscpi.SocketInstrument):
             idleDelay (int): Duration of delay in samples. Default (and minimum) is waveform granularity * 10. Max is (2^25 * gran) + (gran - 1).
             ch (int): Channel for which sequence is created (values are 1 or 2, default is 1).
         """
-        
+
         # Input checking
         if ch not in [1, 2]:
             raise ValueError("ch argument must be 1 or 2.")
@@ -2691,6 +2691,17 @@ class VectorUXG(socketscpi.SocketInstrument):
         self.binblockwrite(f'memory:data "WFM1:{wfmID}", ', wfm)
 
         return wfmID
+
+    def download_bin_pdw_file(self, pdwFile, pdwName="wfm"):
+        """
+        Downloads binary PDW file to PDW directory in UXG.
+        Args:
+            pdwFile (bytes): Binary data containing PDW file, generally created by the bin_pdw_file_builder() method.
+            pdwName (str): Name of PDW file.
+        """
+
+        self.binblockwrite(f'memory:data "/USER/PDW/{pdwName}",', pdwFile)
+        self.err_check()
 
     @staticmethod
     def iq_wfm_combiner(i, q):

--- a/pyarbtools/instruments.py
+++ b/pyarbtools/instruments.py
@@ -2363,7 +2363,8 @@ class AnalogUXG(socketscpi.SocketInstrument):
 
 class VectorUXG(socketscpi.SocketInstrument):
     """
-    Generic class for controlling the N5194A + N5193A (Vector + Analog) UXG agile signal generators.
+    Generic class for controlling the N5194A + N5193A
+    (Vector + Analog) UXG agile signal generators.
 
     Attributes:
         rfState (int): Turns the RF output on or off. (1, 0)
@@ -2376,7 +2377,8 @@ class VectorUXG(socketscpi.SocketInstrument):
         Add check to ensure that the correct instrument is connected
     """
 
-    def __init__(self, host, port=5025, timeout=10, reset=False, clearMemory=False, errCheck=True):
+    def __init__(self, host, port=5025, timeout=10, reset=False,
+                 clearMemory=False, errCheck=True):
         super().__init__(host, port, timeout)
         if reset:
             self.write("*rst")
@@ -2410,11 +2412,14 @@ class VectorUXG(socketscpi.SocketInstrument):
         self.host = host
 
         # Set up separate socket for LAN PDW streaming
-        self.lanStream = socketscpi.socket.socket(socketscpi.socket.AF_INET, socketscpi.socket.SOCK_STREAM)
+        self.lanStream = socketscpi.socket.socket(socketscpi.socket.AF_INET,
+                                                  socketscpi.socket.SOCK_STREAM)
         self.lanStream.setblocking(False)
-        self.lanStream.settimeout(timeout)  # Can't connect until LAN streaming is turned on  # self.lanStream.connect((host, 5033))
+        self.lanStream.settimeout(timeout)
+        # Can't connect until LAN streaming is turned on
+        # self.lanStream.connect((host, 5033))
 
-    # def configure(self, rfState=0, modState=0, cf=1e9, amp=-20, iqScale=70):
+
     def configure(self, **kwargs):
         """
         Sets the basic configuration for the UXG and populates class
@@ -2442,9 +2447,11 @@ class VectorUXG(socketscpi.SocketInstrument):
             elif key == "iqScale":
                 self.set_iqScale(value)
             else:
-                raise KeyError(
-                    f'Invalid keyword argument: "{key}"'
-                )  # raise KeyError('Invalid keyword argument.')  # Arb state can only be turned on after a waveform has been loaded/selected  # self.write(f'radio:arb:state {arbState}')  # self.arbState = self.query('radio:arb:state?').strip()
+                raise KeyError( f'Invalid keyword argument: "{key}"')
+                # raise KeyError('Invalid keyword argument.')
+                # Arb state can only be turned on after a waveform has been loaded/selected
+                # self.write(f'radio:arb:state {arbState}')
+                # self.arbState = self.query('radio:arb:state?').strip()
 
         self.err_check()
 
@@ -2460,7 +2467,8 @@ class VectorUXG(socketscpi.SocketInstrument):
 
     def set_modState(self, modState):
         """
-        Sets and reads the state of the internal baseband modulator using SCPI commands.
+        Sets and reads the state of the internal baseband modulator
+           using SCPI commands.
         Args:
             modState (int): Turns the baseband modulator on or off. (1, 0)
         """
@@ -2470,19 +2478,22 @@ class VectorUXG(socketscpi.SocketInstrument):
 
     def set_cf(self, cf):
         """
-        Sets and reads the center frequency of the signal generator using SCPI commands.
+        Sets and reads the center frequency of the signal generator
+           using SCPI commands.
         Args:
             cf (float): Sets the generator's carrier frequency.
         """
 
         if not isinstance(cf, float) or cf <= 0:
-            raise ValueError("Carrier frequency must be a positive floating point value.")
+            raise ValueError("Carrier frequency must be a positive"
+                             " floating point value.")
         self.write(f"frequency {cf}")
         self.cf = float(self.query("frequency?").strip())
 
     def set_amp(self, amp):
         """
-        Sets and reads the output amplitude of signal generator using SCPI commands.
+        Sets and reads the output amplitude of signal generator
+           using SCPI commands.
         Args:
             amp (int/float): Sets the generator's RF output power.
         """
@@ -2494,19 +2505,19 @@ class VectorUXG(socketscpi.SocketInstrument):
 
     def set_iqScale(self, iqScale):
         """
-        Sets and reads the scaling of the baseband IQ waveform using SCPI commands.
-        Should be about 70 percent to avoid clipping.
+        Sets and reads the scaling of the baseband IQ waveform
+           using SCPI commands. Should be about 70 percent to
+           avoid clipping.
         Args:
-            iqScale (int): Scales the IQ modulator in percent. Default/safe value is 70, range is 0 to 100.
+            iqScale (int): Scales the IQ modulator in percent.
+            Default/safe value is 70, range is 0 to 100.
         """
 
         if not isinstance(iqScale, int) or iqScale <= 0 or iqScale > 100:
             raise ValueError("iqScale argument must be an integer between 1 and 100.")
 
-        # M9381/3A don't have an IQ scaling command.
-        if "M938" not in self.instId:
-            self.write(f"radio:arb:rscaling {iqScale}")
-            self.iqScale = float(self.query("radio:arb:rscaling?").strip())
+        self.write(f"radio:arb:rscaling {iqScale}")
+        self.iqScale = float(self.query("radio:arb:rscaling?").strip())
 
     def stream_configure(
         self,
@@ -2523,29 +2534,34 @@ class VectorUXG(socketscpi.SocketInstrument):
         Args:
             source (str): Selects the streaming source. ('file', 'lan')
             trigState (bool): Configures trigger state. (True, False)
-            trigSource (str): Selects trigger source. ('key', 'bus', 'external', 'timer')
+            trigSource (str): Selects trigger source. ('key', 'bus',
+                                                       'external', 'timer')
             trigInPort (int): Selects trigger input port. (1-10)
             trigPeriod (float): Sets period for timer trigger.
             trigOutPort (int): Selects trigger output port. (1-10)
         """
 
         if source.lower() not in ["file", "lan"]:
-            raise error.UXGError('Invalid stream source selected. Use "file" or "lan"')
+            raise error.UXGError('Invalid stream source selected.'
+                                 ' Use "file" or "lan"')
 
         self.write(f"stream:source {source}")
 
         if trigState:
             if trigSource.lower() not in ["key", "bus", "external", "timer"]:
-                raise error.UXGError('Invalid trigger source selected. Use "key", "bus", "external", or "timer"')
+                raise error.UXGError('Invalid trigger source selected.'
+                                     ' Use "key", "bus", "external", or "timer"')
             if trigInPort == trigOutPort and trigInPort and trigOutPort:
-                raise error.UXGError("Conflicting trigger ports. trigInPort and trigOutPort must be unique.")
+                raise error.UXGError("Conflicting trigger ports. trigInPort and"
+                                     " trigOutPort must be unique.")
             self.write("stream:trigger:play:file:type:continuous:type trigger")
             self.write(f"stream:trigger:play:source {trigSource}")
 
             if trigSource.lower() == "external":
                 if trigInPort:
                     if trigInPort < 1 or trigInPort > 10:
-                        raise error.UXGError("trigInPort must be an integer between 1 and 10.")
+                        raise error.UXGError("trigInPort must be an integer"
+                                             " between 1 and 10.")
                     self.write(f"trigger:play:external:source trigger{trigInPort}")
             elif trigSource.lower() == "timer":
                 if trigPeriod < 48e-9 or trigPeriod > 34:
@@ -2597,28 +2613,51 @@ class VectorUXG(socketscpi.SocketInstrument):
             (bytes): Binary data that contains a full PDW file that can
                 be downloaded to and played out of the UXG.
         """
-
         pdwFile = pdwBuilder.vector_bin_pdw_file_builder(pdwList)
-
         self.err_check()
-
         return pdwFile
 
-    # noinspection PyDefaultArgument,PyDefaultArgument
-    def csv_pdw_file_download(self, fileName, fields=["Operation", "Time"], data=[[1, 0], [2, 100e-6]]):
+
+    def build_raw_pdw_block(self, pdwList):
         """
-        Builds a CSV PDW file, sends it into the UXG, and converts it to a binary PDW file.
+        Builds a raw binary PDW block without a header
+
+        See User's Guide>Streaming Use>PDW Definitions section of
+        Keysight UXG X-Series Agile Vector Adapter Online Documentation
+        http://rfmw.em.keysight.com/wireless/helpfiles/n519xa-vector/n519xa-vector.htm
+        Args:
+            pdwList (list): List of lists. Each inner list contains a single
+        pulse descriptor word.
+
+        Returns:
+            (bytes): Binary data that contains a raw PDWs that can be
+                     streamed to UXG without a header
+        """
+        pdwBlock = pdwBuilder.vector_build_raw_pdw_block_rev3B(pdwList)
+
+        self.err_check()
+        return pdwBlock
+
+    # noinspection PyDefaultArgument,PyDefaultArgument
+    def csv_pdw_file_download(self, fileName, fields=["Operation", "Time"],
+                              data=[[1, 0], [2, 100e-6]]):
+        """
+        Builds a CSV PDW file, sends it into the UXG, then the UXG will
+            convert it to a binary PDW file.
         Args:
             fileName (str): Name of the csv file to be downloaded.
             fields (tuple(str)): Names of the fields contained in PDWs.
-            data (tuple(tuple)): Tuple of tuples. The inner tuples each contain the values for the fields for a single PDW.
+            data (tuple(tuple)): Tuple of tuples. The inner tuples each contain
+                                 the values for the fields for a single PDW.
         """
 
         # Write header fields separated by commas and terminated with \n
         pdwCsv = ",".join(fields) + "\n"
         for row in data:
-            # Write subsequent rows with data values separated by commas and terminated with \n
-            # The .join() function requires a list of strings, so convert numbers in row to strings
+            """Write subsequent rows with data values separated by commas
+               and terminated with \n. The .join() function requires a list
+               of strings, so convert numbers in row to strings
+            """
             rowString = ",".join([f"{r}" for r in row]) + "\n"
             pdwCsv += rowString
 
@@ -2648,20 +2687,23 @@ class VectorUXG(socketscpi.SocketInstrument):
         Writes a waveform index file to be used by a PDW file to select
         waveforms.
         Args:
-            windex (dict): {'fileName': '<fileName>', 'wfmNames': ['<name0>', '<name1>',... '<nameN>']}
+            windex (dict): {'fileName': '<fileName>',
+                            'wfmNames': ['<name0>', '<name1>',... '<nameN>']}
         """
 
         windexCsv = "Id,Filename\n"
         for i in range(len(windex["wfmNames"])):
             windexCsv += f'{i},{windex["wfmNames"][i]}\n'
 
-        self.binblockwrite(f'memory:data "{windex["fileName"]}.csv", ', windexCsv.encode("utf-8"))
+        self.binblockwrite(f'memory:data "{windex["fileName"]}.csv",'
+                           f' ', windexCsv.encode("utf-8"))
 
         """Note: memory:import:windex imports/converts csv to waveform
         index file AND assigns the resulting file as the waveform index
         manager. There is no need to send the stream:windex:select
         command because it is sent implicitly by memory:import:windex."""
-        self.write(f'memory:import:windex "{windex["fileName"]}.csv", "{windex["fileName"]}"')
+        self.write(f'memory:import:windex "{windex["fileName"]}.csv",'
+                   f' "{windex["fileName"]}"')
         self.query("*opc?")
         if self.errCheck:
             self.err_check()
@@ -2679,7 +2721,8 @@ class VectorUXG(socketscpi.SocketInstrument):
         """
 
         if wfmData.dtype != np.complex:
-            raise TypeError("Invalid wfm type. IQ waveforms must be an array of complex values.")
+            raise TypeError("Invalid wfm type. IQ waveforms must be"
+                            " an array of complex values.")
         else:
             i = self.check_wfm(np.real(wfmData))
             q = self.check_wfm(np.imag(wfmData))
@@ -2692,11 +2735,12 @@ class VectorUXG(socketscpi.SocketInstrument):
 
         return wfmID
 
-    def download_bin_pdw_file(self, pdwFile, pdwName="wfm"):
+    def upload_bin_pdw_file(self, pdwFile, pdwName="wfm"):
         """
-        Downloads binary PDW file to PDW directory in UXG.
+        Uploads binary PDW file to PDW directory in UXG.
         Args:
-            pdwFile (bytes): Binary data containing PDW file, generally created by the bin_pdw_file_builder() method.
+            pdwFile (bytes): Binary data containing PDW file, generally
+                             created by the bin_pdw_file_builder() method.
             pdwName (str): Name of PDW file.
         """
 
@@ -2706,7 +2750,8 @@ class VectorUXG(socketscpi.SocketInstrument):
     @staticmethod
     def iq_wfm_combiner(i, q):
         """
-        Combines i and q wfms into a single interleaved wfm for download to generator.
+        Combines i and q wfms into a single interleaved wfm
+           for upload to generator.
         Args:
             i (NumPy array): Array of real waveform samples.
             q (NumPy array): Array of imaginary waveform samples.
@@ -2737,15 +2782,18 @@ class VectorUXG(socketscpi.SocketInstrument):
                 formatted appropriately for download to AWG
         """
 
-        # If waveform length doesn't meet granularity or minimum length requirements, repeat the waveform until it does
+        # If waveform length doesn't meet granularity or minimum
+        # length requirements, repeat the waveform until it does
         repeats = wraparound_calc(len(wfm), self.gran, self.minLen)
         wfm = np.tile(wfm, repeats)
         rl = len(wfm)
 
         if rl < self.minLen:
-            raise error.VSGError(f"Waveform length: {rl}, must be at least {self.minLen}.")
+            raise error.VSGError(f"Waveform length: {rl},"
+                                 f" must be at least {self.minLen}.")
         if rl % self.gran != 0:
-            raise error.GranularityError(f"Waveform must have a granularity of {self.gran}.")
+            raise error.GranularityError(f"Waveform must have a "
+                                         f"granularity of {self.gran}.")
 
         if bigEndian:
             return np.array(self.binMult * wfm, dtype=np.uint16).byteswap()

--- a/pyarbtools/pdwBuilder.py
+++ b/pyarbtools/pdwBuilder.py
@@ -538,6 +538,29 @@ def vector_bin_pdw_builder(operation, freq, phase, startTimeSec, powerDbm,
     return pdw
 
 
+def vector_build_raw_pdw_block_rev3B(pdwList):
+    """
+    Builds a raw binary pdw block without header
+
+    See User's Guide>Streaming Use>PDW Definitions section of
+    Keysight UXG X-Series Agile Vector Adapter Online Documentation
+    http://rfmw.em.keysight.com/wireless/helpfiles/n519xa-vector/n519xa-vector.htm
+    Args:
+        pdwList (list): List of lists. Each inner list contains a single
+    pulse descriptor word.
+
+    Returns:
+        (bytes): Binary data that contains a raw PDW binary block
+                 without header.  This can be streamed directly to UXG
+    """
+    pdwData = []
+    pdwData += [vector_bin_pdw_builder_rev3b(*p) for p in pdwList]
+    # Convert arrays of data to a single byte-type variable
+    pdwData = b''.join(pdwData)
+
+    return pdwData
+
+
 # noinspection PyRedundantParentheses
 def vector_bin_pdw_file_builder(pdwList):
     """

--- a/pyarbtools/pdwBuilder.py
+++ b/pyarbtools/pdwBuilder.py
@@ -385,74 +385,11 @@ def analog_bin_pdw_file_builder(pdwList):
     return pdwFile
 
 
-# noinspection PyPep8
-def vector_bin_pdw_builder_3(operation=0, freq=1e9, phase=0, startTimeSec=0, width=10e-6,
-                             maxPower=0, markers=0, powerDbm=0, phaseControl=0, rfOff=0,
-                             autoBlank=0, zeroHold=0, loLead=0, wfmMkrMask=0, wIndex=0):
-    """
-    This function builds a single format-3 PDW from a list of parameters.
-
-    See User's Guide>Streaming Use>PDW Definitions section of
-    Keysight UXG X-Series Agile Vector Adapter Online Documentation
-    http://rfmw.em.keysight.com/wireless/helpfiles/n519xa-vector/n519xa-vector.htm
-    Args:
-        operation (int): Specifies the operation of the PDW. (0-none, 1-first PDW, 2-last PDW)
-        freq (float): CW frequency of PDW.
-        phase (float): Phase of CW frequency of PDW.
-        startTimeSec (float): Start time of the 50% rising edge power.
-        width (float): Width of the pulse from 50% rise power to 50% fall power.
-        maxPower (float): Max output power in dBm.
-        markers (int): Enables or disables PDW markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
-        powerDbm (float): Sets power for individual PDW in dBm.
-        phaseControl (int): Switches between phase mode. (0-coherent, 1-continuous)
-        rfOff (int): Activates or deactivates RF Off mode. (0-RF on, 1-RF off). I know, the nomenclature here is TRASH.
-        autoBlank (int): Activates blanking. (0-no blanking, 1-blanking)
-        zeroHold (int): Selects zero/hold behavior. (0-zero, 1-hold last value)
-        loLead (float): Specifies how long before the PDW start time to begin switching LO.
-        wfmMkrMask (int): Enables or disables waveform markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
-        wIndex (int): Index of the IQ waveform to be assigned to the PDW.
-
-    Returns:
-        (NumPy array): Single PDW that can be used to build a PDW file or streamed directly to the UXG.
-    """
-    pdwFormat = 3
-    _freq = int(freq * 1024 + 0.5)
-    _phase = int(phase * 4096 / 360 + 0.5)
-    _startTimePs = int(startTimeSec * 1e12)
-    # you multiplied this by 2, it's probably not going to work.
-    _pulseWidthPs = int(width * 1e12 * 2)
-    _maxPower = int((maxPower + 140) / 0.005 + 0.5)
-    _power = int((powerDbm + 140) / 0.005 + 0.5)
-    _loLead = int(loLead / 4e-9)
-    _newWfm = 1
-    _wfmType = 0
-
-    # Build PDW
-    pdw = np.zeros(11, dtype=np.uint32)
-    # Word 0: Mask pdw format (3 bits), operation (2 bits), and the lower 27 bits of freq
-    pdw[0] = (pdwFormat | operation << 3 | _freq << 5) & 0xFFFFFFFF
-    # Word 1: Mask the upper 20 bits (47 - 27) of freq and phase (12 bits)
-    pdw[1] = (_freq >> 27 | _phase << 20) & 0xFFFFFFFF
-    # Word 2: Lower 32 bits of startTimePs
-    pdw[2] = _startTimePs & 0xFFFFFFFF
-    # Word 3: Upper 32 bits of startTimePS
-    pdw[3] = (_startTimePs & 0xFFFFFFFF00000000) >> 32
-    # Word 4: Lower 32 bits of Pulse width (37 bits)
-    pdw[4] = _pulseWidthPs & 0xFFFFFFFF
-    # Word 5: Upper 5 bits of Pulse width, max power (15 bits), markers (12 bits)
-    pdw[5] = (_pulseWidthPs & 0x1F00000000) >> 32 | _maxPower << 5 | markers << 20
-    # Word 6: Power (15 bits), phase mode (1), RF off (1), auto blank (1), new wfm (1),
-    # zero/hold (1), lo lead (8), marker mask (4)
-    pdw[6] = _power | phaseControl << 15 | rfOff << 16 | autoBlank << 17 | _newWfm << 18 | zeroHold << 19 | _loLead << 20 | wfmMkrMask << 28
-    # Word 7: Reserved (8), Wfm type (2), index (16) reserved (
-    pdw[7] = _wfmType << 8 | wIndex << 10
-
-    return pdw
-
-def vector_bin_pdw_builder_3b(operation=0, freq=1e9, phase=0, startTimeSec=0, width=10e-6,
-                              maxPower=0, markers=0, powerDbm=0, phaseControl=0, rfOff=0,
-                              autoBlank=0, newWaveform=1, zeroHold=0, loLead=0, wfmMkrMask=0,
-                              wIndex=0, power2dBm=0, maxPower2dBm=0, dopplerHz = 0):
+def vector_bin_pdw_builder_rev3b(operation=0, freq=1e9, phase=0, startTimeSec=0,
+                                 width=0, maxPower=0, markers=0, powerDbm=0,
+                                 phaseControl=0, rfOff=0, autoBlank=1,
+                                 newWaveform=1, zeroHold=0, loLead=0, wfmMkrMask=0,
+                                 wIndex=0, power2dBm=0, maxPower2dBm=0, dopplerHz = 0):
     """
     This function builds a single format-3 PDW Rev B (fw A.01.30 and later)
     from a list of parameters.
@@ -461,35 +398,47 @@ def vector_bin_pdw_builder_3b(operation=0, freq=1e9, phase=0, startTimeSec=0, wi
     Keysight UXG X-Series Agile Vector Adapter Online Documentation
     http://rfmw.em.keysight.com/wireless/helpfiles/n519xa-vector/n519xa-vector.htm
     Args:
-        operation (int): Specifies the operation of the PDW. (0-none, 1-first PDW, 2-last PDW)
+        operation (int): Specifies the operation of the PDW.
+                        (0-none, 1-first PDW, 2-last PDW)
         freq (float): CW frequency of PDW.
         phase (float): Phase of CW frequency of PDW.
         startTimeSec (float): Start time of the 50% rising edge power.
-        width (float): Width of the pulse from 50% rise power to 50% fall power.
+        width (float): Width of the pulse from 50% rise power
+                        to 50% fall power seconds.
         maxPower (float): Max output power in dBm.
-        markers (int): Enables or disables PDW markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
+        markers (int): Enables or disables PDW markers via bit masking.
+                        (e.g. to activate marker 3, send the number 4,
+                        which is 0100 in binary).
         powerDbm (float): Sets power for individual PDW in dBm.
-        phaseControl (int): Switches between phase mode. (0-coherent, 1-continuous)
-        rfOff (int): Activates or deactivates RF Off mode. (0-RF on, 1-RF off). I know, the nomenclature here is TRASH.
+        phaseControl (int): Switches between phase mode.
+                        (0-coherent, 1-continuous)
+        rfOff (int): Activates or deactivates RF Off mode.
+                        (0-RF on, 1-RF off).
+                        Note: This nomenclature is not intuitive.
         autoBlank (int): Activates blanking. (0-no blanking, 1-blanking)
-        newWaveform (int): (0-continue with prior PDW settings, 1-start with all new pdw settings)
-        zeroHold (int): Selects zero/hold behavior. (0-zero, 1-hold last value)
-        loLead (float): Specifies how long before the PDW start time to begin switching LO.
-        wfmMkrMask (int): Enables or disables waveform markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
+        newWaveform (int): (0-continue with prior PDW settings,
+                            1-start with all new pdw settings)
+        zeroHold (int): Selects zero/hold behavior.
+                        (0-zero, 1-hold last value)
+        loLead (float): Specifies how long before the PDW start time to
+                        begin switching LO.
+        wfmMkrMask (int): Enables or disables waveform markers via bit
+                            masking. (e.g. to activate marker 3, send the
+                            number 4, which is 0100 in binary).
         wIndex (int): Index of the IQ waveform to be assigned to the PDW.
         power2dBm (float): Alternate (second) desired output power in dBm - pdw Rev B
         maxPower2dBm (float): Alternate max power output - pdw Rev B
         dopplerHz (float): Doppler frequency - pdw Rev B
 
     Returns:
-        (NumPy array): Single PDW that can be used to build a PDW file or streamed directly to the UXG.
+        (NumPy array): Single PDW that can be used to build a PDW file or streamed
+                        directly to the UXG.
     """
     pdwFormat = 3
     _freq = int(freq * 1024 + 0.5)
     _phase = int(phase * 4096 / 360 + 0.5)
     _startTimePs = int(startTimeSec * 1e12)
-    # you multiplied this by 2, it's probably not going to work.
-    _pulseWidthPs = int(width * 1e12 * 2)
+    _pulseWidthInHalfNs = int(width * 1e9 * 2)
     _maxPower = int((maxPower + 140) / 0.005 + 0.5)
     _power = int((powerDbm + 140) / 0.005 + 0.5)
     _loLead = int(loLead / 4e-9)
@@ -500,37 +449,40 @@ def vector_bin_pdw_builder_3b(operation=0, freq=1e9, phase=0, startTimeSec=0, wi
     _doppler = int(dopplerHz + 0.5)
 
     # Build PDW
-    pdw = np.zeros(11, dtype=np.uint32)
-    # Word 0: Mask pdw format (3 bits), operation (2 bits), and the lower 27 bits of freq
+    pdw = np.zeros(12, dtype=np.uint32)
+    # Word 0: Mask pdw format (3 bits), operation (2 bits), freqLower (27 bits)
     pdw[0] = (pdwFormat | operation << 3 | _freq << 5) & 0xFFFFFFFF
-    # Word 1: Mask the upper 20 bits (47 - 27) of freq and phase (12 bits)
+    # Word 1: freqUpper (20 bits 47-27) of freq and phase (12 bits)
     pdw[1] = (_freq >> 27 | _phase << 20) & 0xFFFFFFFF
     # Word 2: Lower 32 bits of startTimePs
     pdw[2] = _startTimePs & 0xFFFFFFFF
     # Word 3: Upper 32 bits of startTimePS
     pdw[3] = (_startTimePs & 0xFFFFFFFF00000000) >> 32
     # Word 4: Lower 32 bits of Pulse width (37 bits)
-    pdw[4] = _pulseWidthPs & 0xFFFFFFFF
+    pdw[4] = _pulseWidthInHalfNs & 0xFFFFFFFF
     # Word 5: Upper 5 bits of Pulse width, max power (15 bits), markers (12 bits)
-    pdw[5] = (_pulseWidthPs & 0x1F00000000) >> 32 | _maxPower << 5 | markers << 20
-    # Word 6: Power (15 bits), phase mode (1), RF off (1), auto blank (1), new wfm (1),
-    # zero/hold (1), lo lead (8), marker mask (4)
+    pdw[5] = (_pulseWidthInHalfNs & 0x1F00000000) >> 32 | \
+             _maxPower << 5 | markers << 20
+    # Word 6: Power (15 bits), phase mode (1), RF off (1), auto blank (1),
+    #           new wfm (1), zero/hold (1), lo lead (8), marker mask (4)
     pdw[6] = _power | phaseControl << 15 | rfOff << 16 | autoBlank << 17 |\
              _newWfm << 18 | zeroHold << 19 | _loLead << 20 | wfmMkrMask << 28
     # Word 7: Reserved (8), Wfm type (2), index (16), power2low (6)
     pdw[7] = (_wfmType << 8 | wIndex << 10 | _power2 << 26) & 0xFFFFFFFF
     # Word 8: power2high (9), max power (15), reserved (8)
     pdw[8] = _power2 >> 6 | _maxPower2 << 9
-    # Word 9: reserved (16), reserved (16), dopplerLow (9)
-    pdw[9] = (0 | _doppler << 2 ) & 0xFFFFFFFF
-    # Word 10: dopplerHigh (12), reserved (11), reserved (9)
-    pdw[10] = _doppler >> 9
+    # Word 9: reserved (16), reserved (16)
+    pdw[9] = 0
+    # Word 10: reserved (4), reserved (2), reserved (17), dopplerLow (9)
+    pdw[10] = (_doppler << 23) & 0xFFFFFFFF
+    # Word 11: dopplerHigh (12), reserved (11), reserved (9)
+    pdw[11] = _doppler >> 9
 
     return pdw
 
 
-
-def vector_bin_pdw_builder(operation, freq, phase, startTimeSec, powerDbm, markers, phaseControl, rfOff, wIndex, wfmMkrMask):
+def vector_bin_pdw_builder(operation, freq, phase, startTimeSec, powerDbm,
+                           markers, phaseControl, rfOff, wIndex, wfmMkrMask):
     """
     This function builds a single format-1 PDW from a list of parameters.
     PDW format-1 is now deprecated.  This format is still supported as legacy
@@ -539,19 +491,26 @@ def vector_bin_pdw_builder(operation, freq, phase, startTimeSec, powerDbm, marke
     Keysight UXG X-Series Agile Vector Adapter Online Documentation
     http://rfmw.em.keysight.com/wireless/helpfiles/n519xa-vector/n519xa-vector.htm
     Args:
-        operation (int): Specifies the operation of the PDW. (0-none, 1-first PDW, 2-last PDW)
+        operation (int): Specifies the operation of the PDW.
+                         (0-none, 1-first PDW, 2-last PDW)
         freq (float): CW frequency of PDW.
         phase (float): Phase of CW frequency of PDW.
         startTimeSec (float): Start time of the 50% rising edge power.
         powerDbm (float): Sets power for individual PDW in dBm.
-        markers (int): Enables or disables PDW markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
+        markers (int): Enables or disables PDW markers via bit masking.
+                       (e.g. to activate marker 3, send the number 4,
+                       which is 0100 in binary).
         phaseControl (int): Switches between phase mode. (0-coherent, 1-continuous)
-        rfOff (int): Activates or deactivates RF Off mode. (0-RF on, 1-RF off). I know, the nomenclature here is TRASH.
+        rfOff (int): Activates or deactivates RF Off mode. (0-RF on, 1-RF off).
+                     I know, the nomenclature here is TRASH.
         wIndex (int): Index of the IQ waveform to be assigned to the PDW.
-        wfmMkrMask (int): Enables or disables waveform markers via bit masking. (e.g. to activate marker 3, send the number 4, which is 0100 in binary).
+        wfmMkrMask (int): Enables or disables waveform markers via bit masking.
+                          (e.g. to activate marker 3, send the number 4,
+                          which is 0100 in binary).
 
     Returns:
-        (NumPy array): Single PDW that can be used to build a PDW file or streamed directly to the UXG.
+        (NumPy array): Single PDW that can be used to build a PDW file or
+                       streamed directly to the UXG.
     """
 
     # Format 1 PDWs are deprecated
@@ -626,7 +585,7 @@ def vector_bin_pdw_file_builder(pdwList):
 
     # Build PDW file from header, padBlock, pdwBlock, and PDWs
     pdwFile = header + padding + pdwBlock
-    pdwFile += [vector_bin_pdw_builder(*p) for p in pdwList]
+    pdwFile += [vector_bin_pdw_builder_rev3b(*p) for p in pdwList]
     # Convert arrays of data to a single byte-type variable
     pdwFile = b''.join(pdwFile)
 


### PR DESCRIPTION
examples.py:
Changed names of vector UXG examples to clarify if streaming was done from csv file, binary file, or LAN streaming.  Added separate file and LAN streaming examples.  Export file streaming example to file on N5194A to make it easier to troubleshoot streaming.

Formatted comments to align tables and wrap text (easier to read on printouts)


instruments.py:
Class VectorUXG():
Removed check for M9381/3A in vector UXG driver.  No need to check here since this will always be N5194A.
Added build_raw_pdw_block() to facilitate building pdw block without a header for LAN streaming.
Added upload_bin_pdw_file()  method

Formatted comments to make easier to read on printouts


pdwBuilder.py:
analog_bin_pdw_file_builder():
Refactored pdw block size algorithm.  Makes it easier to debug.

Changed name of vector_bin_pdw_builder_3() to vector_bin_pdw_builder_rev3b() to be explicit.  vector_bin_pdw_builder_3() was not referenced or used anywhere before, so this updates it.

Formatted comments to make easier to read on printouts


vector_bin_pdw_builder():
Formatted comments to make easier to read on printouts

Added vector_build_raw_pdw_block_rev3B():


vector_bin_pdw_file_builder():
POTENTIAL BREAKING CHANGE:  Changed reference to vector_bin_pdw_builder() to vector_bin_pdw_builder_rev3b().

vector_bin_pdw_builder() uses depracated pdw format 1.  vector_bin_pdw_builder_rev3b() uses the currently supported pdw rev 3b.

Jeff
